### PR TITLE
fix group config cascade and docs logo base path

### DIFF
--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -1,3 +1,5 @@
+const baseURL = (process.env.NUXT_APP_BASE_URL || '/').replace(/\/$/, '')
+
 export default defineAppConfig({
   ui: {
     colors: {
@@ -12,8 +14,8 @@ export default defineAppConfig({
   header: {
     title: '@kolirt/vue-modal',
     logo: {
-      light: '/logo.png',
-      dark: '/logo.png',
+      light: `${baseURL}/logo.png`,
+      dark: `${baseURL}/logo.png`,
       alt: '@kolirt/vue-modal'
     }
   },

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -7,7 +7,13 @@ export default defineNuxtConfig({
   },
   app: {
     head: {
-      link: [{ rel: 'icon', type: 'image/png', href: '/logo.png' }]
+      link: [
+        {
+          rel: 'icon',
+          type: 'image/png',
+          href: `${(process.env.NUXT_APP_BASE_URL || '/').replace(/\/$/, '')}/logo.png`
+        }
+      ]
     }
   },
   mdc: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kolirt/vue-modal",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Open modals from any function, stack them as needed, and style them however you want. No template boilerplate, no manual state — just call and await.",
   "author": "kolirt",

--- a/packages/core/src/components/target/ModalTarget.vue
+++ b/packages/core/src/components/target/ModalTarget.vue
@@ -13,13 +13,7 @@ import type { ModalBehaviorOptions } from '../../types'
 import ModalSlot from './ModalSlot.vue'
 import type { ModalTargetProps } from './interface'
 
-const props = withDefaults(defineProps<ModalTargetProps>(), {
-  enableInteractOutside: false,
-  disableCloseOnInteractOutside: false,
-  disableCloseOnInteractOverlay: false,
-  disableLockBodyScroll: false,
-  disableCloseOnEscape: false
-})
+const props = defineProps<ModalTargetProps>()
 
 const regionRef = ref<HTMLElement | null>(null)
 


### PR DESCRIPTION
- ModalTarget no longer applies withDefaults to behavior options, so undefined props correctly fall through to createModal group config
- docs logo and favicon now respect NUXT_APP_BASE_URL for GitHub Pages
- bump @kolirt/vue-modal to 2.0.1