### PR TITLE
fix: docs logo on GitHub Pages

### DIFF
--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -1,5 +1,3 @@
-const baseURL = (process.env.NUXT_APP_BASE_URL || '/').replace(/\/$/, '')
-
 export default defineAppConfig({
   ui: {
     colors: {
@@ -14,8 +12,8 @@ export default defineAppConfig({
   header: {
     title: '@kolirt/vue-modal',
     logo: {
-      light: `${baseURL}/logo.png`,
-      dark: `${baseURL}/logo.png`,
+      light: '/logo.png',
+      dark: '/logo.png',
       alt: '@kolirt/vue-modal'
     }
   },

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -21,5 +21,8 @@ export default defineNuxtConfig({
       shikiEngine: 'javascript'
     }
   },
+  image: {
+    provider: 'none'
+  },
   compatibilityDate: '2025-07-22'
 })


### PR DESCRIPTION
Switch @nuxt/image to provider: 'none' so the static build emits the real /vue-modal/logo.png path instead of /_ipx/ URLs that have no corresponding files. Revert the manual baseURL prefix in app.config.ts since UColorModeImage already resolves baseURL itself.